### PR TITLE
 CI pipeline entry point success, push only

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -1,15 +1,16 @@
 name: 🤖 Android Builds
-on: [push, pull_request]
+on:
+  workflow_call:
+
+concurrency:
+  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-static
+  cancel-in-progress: true
 
 # Global Settings
 env:
   # Only used for the cache key. Increment version to force clean build.
   GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no module_text_server_fb_enabled=yes
-
-concurrency:
-  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-android
-  cancel-in-progress: true
 
 jobs:
   android-template:

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -1,15 +1,16 @@
 name: 🍏 iOS Builds
-on: [push, pull_request]
+on:
+  workflow_call:
+
+concurrency:
+  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-static
+  cancel-in-progress: true
 
 # Global Settings
 env:
   # Only used for the cache key. Increment version to force clean build.
   GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no module_text_server_fb_enabled=yes
-
-concurrency:
-  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-ios
-  cancel-in-progress: true
 
 jobs:
   ios-template:

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -1,5 +1,11 @@
 name: 🐧 Linux Builds
-on: [push, pull_request]
+on:
+  workflow_call:
+
+concurrency:
+  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-static
+  cancel-in-progress: true
+
 
 # Global Settings
 env:
@@ -8,10 +14,6 @@ env:
   SCONSFLAGS: verbose=yes warnings=extra werror=yes module_text_server_fb_enabled=yes
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: false
-
-concurrency:
-  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-linux
-  cancel-in-progress: true
 
 jobs:
   build-linux:

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -1,15 +1,17 @@
 name: 🍎 macOS Builds
-on: [push, pull_request]
+on:
+  workflow_call:
+
+concurrency:
+  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-static
+  cancel-in-progress: true
+
 
 # Global Settings
 env:
   # Only used for the cache key. Increment version to force clean build.
   GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=extra werror=yes module_text_server_fb_enabled=yes
-
-concurrency:
-  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-macos
-  cancel-in-progress: true
 
 jobs:
   build-macos:

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -1,0 +1,35 @@
+name: "Pipeline Entry point"
+on: [push, pull_request]
+
+concurrency:
+  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-static
+  cancel-in-progress: true
+
+jobs:
+  static-checks:
+    uses: ./.github/workflows/test_exit0.yml
+    #uses: ./.github/workflows/static_checks.yml
+
+  android-build:
+    needs: static-checks
+    uses: ./.github/workflows/android_builds.yml
+
+  ios-build:
+    needs: static-checks
+    uses: ./.github/workflows/ios_builds.yml
+
+  linux-build:
+    needs: static-checks
+    uses: ./.github/workflows/linux_builds.yml
+
+  macos-build:
+    needs: static-checks
+    uses: ./.github/workflows/macos_builds.yml
+
+  window-build:
+    needs: static-checks
+    uses: ./.github/workflows/windows_builds.yml
+
+  web-build:
+    needs: static-checks
+    uses: ./.github/workflows/web_builds.yml

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -1,5 +1,6 @@
 name: "Pipeline Entry point"
-on: [push, pull_request]
+on:
+  - push
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-static

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -1,9 +1,11 @@
-name: 📊 Static Checks
-on: [push, pull_request]
+name: "📊 Static Checks"
+on:
+  workflow_call:
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-static
   cancel-in-progress: true
+
 
 jobs:
   static-checks:

--- a/.github/workflows/test_exit0.yml
+++ b/.github/workflows/test_exit0.yml
@@ -1,0 +1,12 @@
+name: "Testing Job"
+on:
+  workflow_call:
+
+jobs:
+  static-checks:
+    name: exit condition test
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Exit
+        run: |
+          exit 0

--- a/.github/workflows/test_exit1.yml
+++ b/.github/workflows/test_exit1.yml
@@ -1,0 +1,12 @@
+name: "Testing Job"
+on:
+  workflow_call:
+
+jobs:
+  static-checks:
+    name: exit condition test
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Exit
+        run: |
+          exit 1

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -1,5 +1,11 @@
 name: 🌐 Web Builds
-on: [push, pull_request]
+on:
+  workflow_call:
+
+concurrency:
+  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-static
+  cancel-in-progress: true
+
 
 # Global Settings
 env:
@@ -8,10 +14,6 @@ env:
   SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no
   EM_VERSION: 3.1.20
   EM_CACHE_FOLDER: "emsdk-cache"
-
-concurrency:
-  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-web
-  cancel-in-progress: true
 
 jobs:
   web-template:

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -1,5 +1,10 @@
 name: 🏁 Windows Builds
-on: [push, pull_request]
+on:
+  workflow_call:
+
+concurrency:
+  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-static
+  cancel-in-progress: true
 
 # Global Settings
 # SCONS_CACHE for windows must be set in the build environment
@@ -8,10 +13,6 @@ env:
   GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=all werror=yes module_text_server_fb_enabled=yes
   SCONS_CACHE_MSVC_CONFIG: true
-
-concurrency:
-  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-windows
-  cancel-in-progress: true
 
 jobs:
   build-windows:


### PR DESCRIPTION
- run pipeline only on `push`, as it runs twice when `pull_request` is present too for some reason
