### PR TITLE
ci runner: break build in the branch

### DIFF
--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -2617,6 +2617,8 @@ void AnimatedTexture::_update_proxy() {
 
 	time += delta;
 
+	float unused = 1;
+
 	float limit;
 
 	if (fps == 0) {


### PR DESCRIPTION
- build is intentionally broken to be sure the pipeline workflows run on the correct branch